### PR TITLE
RFC8974: Add in support for Extended Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The following RFCs are supported
 
 * RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option
 
+* RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)
+
 * RFC9175: CoAP: Echo, Request-Tag, and Token Processing
 
 There is (D)TLS support for the following libraries

--- a/doc/main.md
+++ b/doc/main.md
@@ -40,6 +40,8 @@ The following RFCs are supported
 
 * RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option
 
+* RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)
+
 * RFC9175: CoAP: Echo, Request-Tag, and Token Processing
 
 There is (D)TLS support for the following libraries

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -59,6 +59,7 @@ static uint8_t key[MAX_KEY];
 static ssize_t key_length = 0;
 static int key_defined = 0;
 static const char *hint = "CoAP";
+static size_t extended_token_size = COAP_TOKEN_DEFAULT_MAX;
 
 #ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
@@ -583,6 +584,7 @@ usage( const char *program, const char *version) {
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
      "Usage: %s [-g group] [-G group_if] [-p port] [-v num] [-A address]\n"
+     "\t       [-T max_token_size]\n"
      "\t       [[-h hint] [-k key]]\n"
      "\t       [[-c certfile] [-C cafile] [-n] [-R trust_casfile]]\n"
      "General Options\n"
@@ -595,6 +597,7 @@ usage( const char *program, const char *version) {
      "\t-v num \t\tVerbosity level (default 3, maximum is 9). Above 7,\n"
      "\t       \t\tthere is increased verbosity in GnuTLS and OpenSSL logging\n"
      "\t-A address\tInterface address to bind to\n"
+     "\t-T max_token_length\tSet the maximum token length (8-65804)\n"
      "PSK Options (if supported by underlying (D)TLS library)\n"
      "\t-h hint\t\tIdentity Hint. Default is CoAP. Zero length is no hint\n"
      "\t-k key \t\tPre-Shared Key. This argument requires (D)TLS with PSK\n"
@@ -772,6 +775,20 @@ finish:
   return ctx;
 }
 
+static int
+cmdline_read_extended_token_size(char *arg) {
+  extended_token_size = strtoul(arg, NULL, 0);
+  if (extended_token_size < COAP_TOKEN_DEFAULT_MAX) {
+    coap_log(LOG_ERR, "Extended Token Length must be 8 or greater\n");
+    return 0;
+  }
+  else if (extended_token_size > COAP_TOKEN_EXT_MAX) {
+    coap_log(LOG_ERR, "Extended Token Length must be 65804 or less\n");
+    return 0;
+  }
+  return 1;
+}
+
 int
 main(int argc, char **argv) {
   coap_context_t  *ctx;
@@ -786,7 +803,7 @@ main(int argc, char **argv) {
   struct sigaction sa;
 #endif
 
-  while ((opt = getopt(argc, argv, "A:c:C:g:G:h:k:n:R:p:v:")) != -1) {
+  while ((opt = getopt(argc, argv, "A:c:C:g:G:h:k:n:p:R:T:v:")) != -1) {
     switch (opt) {
     case 'A' :
       strncpy(addr_str, optarg, NI_MAXHOST-1);
@@ -822,12 +839,17 @@ main(int argc, char **argv) {
     case 'n':
       verify_peer_cert = 0;
       break;
-    case 'R' :
-      root_ca_file = optarg;
-      break;
     case 'p' :
       strncpy(port_str, optarg, NI_MAXSERV-1);
       port_str[NI_MAXSERV - 1] = '\0';
+      break;
+    case 'R' :
+      root_ca_file = optarg;
+      break;
+    case 'T':
+      if (!cmdline_read_extended_token_size(optarg)) {
+        exit(1);
+      }
       break;
     case 'v' :
       log_level = strtol(optarg, NULL, 10);
@@ -850,6 +872,8 @@ main(int argc, char **argv) {
     coap_join_mcast_group_intf(ctx, group, group_if);
 
   init_resources(ctx);
+  if (extended_token_size > COAP_TOKEN_DEFAULT_MAX)
+    coap_context_set_max_token_size(ctx, extended_token_size);
 
 #ifdef _WIN32
   signal(SIGINT, handle_sigint);

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -148,8 +148,6 @@ struct coap_lg_srcv_t {
   coap_resource_t *resource; /**< associated resource */
   coap_str_const_t *uri_path; /** set to uri_path if unknown resource */
   coap_rblock_t rec_blocks; /** < list of received blocks */
-  uint8_t last_token[8]; /**< last used token */
-  size_t last_token_length; /**< length of token */
   coap_mid_t last_mid;   /**< Last received mid for this set of packets */
   coap_tick_t last_used; /**< Last time data sent or 0 */
   uint16_t block_option; /**< Block option in use */

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -142,6 +142,7 @@ struct coap_context_t {
                                         when creating a cache-key */
 #endif /* COAP_SERVER_SUPPORT */
   void *app;                       /**< application-specific data */
+  uint32_t max_token_size;         /**< Largest token size supported RFC8974 */
 #ifdef COAP_EPOLL_SUPPORT
   int epfd;                        /**< External FD for epoll */
   int eptimerfd;                   /**< Internal FD for timeout */
@@ -265,12 +266,10 @@ coap_wait_ack( coap_context_t *context, coap_session_t *session,
  * @param context      The context in use.
  * @param session      Session of the messages to remove.
  * @param token        Message token.
- * @param token_length Actual length of @p token.
  */
 void coap_cancel_all_messages(coap_context_t *context,
                               coap_session_t *session,
-                              const uint8_t *token,
-                              size_t token_length);
+                              coap_bin_const_t *token);
 
 /**
 * Cancels all outstanding messages for session @p session.

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -45,6 +45,12 @@
 #define COAP_MAX_MESSAGE_SIZE_TCP16 (COAP_MESSAGE_SIZE_OFFSET_TCP32-1) /* 65804 */
 #define COAP_MAX_MESSAGE_SIZE_TCP32 (COAP_MESSAGE_SIZE_OFFSET_TCP32+0xFFFFFFFF)
 
+/* Extended Token constants */
+#define COAP_TOKEN_EXT_1B_TKL 13
+#define COAP_TOKEN_EXT_2B_TKL 14
+#define COAP_TOKEN_EXT_1B_BIAS 13
+#define COAP_TOKEN_EXT_2B_BIAS 269 /* 13 + 256 */
+
 #ifndef COAP_DEBUG_BUF_SIZE
 #if defined(WITH_CONTIKI) || defined(WITH_LWIP)
 #define COAP_DEBUG_BUF_SIZE 128
@@ -112,16 +118,19 @@ struct coap_pdu_t {
   uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actual size used for protocol-specific
                                  header (0 until header is encoded) */
-  uint8_t token_length;     /**< length of Token */
   uint8_t crit_opt;         /**< Set if unknown critical option for proxy */
   uint16_t max_opt;         /**< highest option number in PDU */
+  uint32_t token_length;    /**< length of Token space (includes leading
+                                 extended bytes */
+  coap_bin_const_t actual_token; /**< Actual token in pdu */
   size_t alloc_size;        /**< allocated storage for token, options and
                                  payload */
   size_t used_size;         /**< used bytes of storage for token, options and
                                  payload */
   size_t max_size;          /**< maximum size for token, options and payload,
                                  or zero for variable size pdu */
-  uint8_t *token;           /**< first byte of token, if any, or options */
+  uint8_t *token;           /**< first byte of token (or extended length bytes
+                                 prefix), if any, or options */
   uint8_t *data;            /**< first byte of payload, if any */
 #ifdef WITH_LWIP
   struct pbuf *pbuf;        /**< lwIP PBUF. The package data will always reside

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -43,6 +43,15 @@ struct coap_addr_hash_t {
 };
 
 /**
+ * coap_ext_token_check_t values
+ */
+typedef enum coap_ext_token_check_t {
+  COAP_EXT_T_NOT_CHECKED = 0, /**< Not checked */
+  COAP_EXT_T_CHECKED,         /**< Token size valid */
+  COAP_EXT_T_CHECKING,        /**< Token size check request sent */
+} coap_ext_token_check_t;
+
+/**
  * Abstraction of virtual session that can be attached to coap_context_t
  * (client) or coap_endpoint_t (server).
  */
@@ -139,6 +148,7 @@ struct coap_session_t {
   unsigned int dtls_timeout_count;      /**< dtls setup retry counter */
   int dtls_event;                       /**< Tracking any (D)TLS events on this
                                              sesison */
+  uint32_t tx_rtag;               /**< Next Request-Tag number to use */
   uint8_t csm_bert_rem_support;  /**< CSM TCP BERT blocks supported (remote) */
   uint8_t csm_bert_loc_support;  /**< CSM TCP BERT blocks supported (local) */
   uint8_t block_mode;             /**< Zero or more COAP_BLOCK_ or'd options */
@@ -147,7 +157,11 @@ struct coap_session_t {
   uint8_t delay_recursive;        /**< Set if in coap_client_delay_first() */
   uint8_t no_observe_cancel;      /**< Set if do not cancel observe on session
                                        close */
-  uint32_t tx_rtag;               /**< Next Request-Tag number to use */
+  volatile uint8_t max_token_checked; /**< Check for max token size
+                                           coap_ext_token_check_t */
+  uint16_t max_token_mid;         /**< mid used for checking ext token
+                                       support */
+  uint32_t max_token_size;        /**< Largest token size supported RFC8974 */
   uint64_t tx_token;              /**< Next token number to use */
   coap_bin_const_t *last_token;   /** last token used to make a request */
   coap_bin_const_t *echo;         /**< Echo value to send with next request */

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -79,7 +79,7 @@ void coap_subscription_init(coap_subscription_t *);
 void
 coap_handle_failed_notify(coap_context_t *context,
                           coap_session_t *session,
-                          const coap_binary_t *token);
+                          const coap_bin_const_t *token);
 
 /**
  * Checks all known resources to see if they are dirty and then notifies
@@ -105,7 +105,7 @@ void coap_check_notify(coap_context_t *context);
  */
 coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        coap_session_t *session,
-                                       const coap_binary_t *token,
+                                       const coap_bin_const_t *token,
                                        const coap_pdu_t *pdu);
 
 /**
@@ -119,7 +119,7 @@ coap_subscription_t *coap_add_observer(coap_resource_t *resource,
  */
 coap_subscription_t *coap_find_observer(coap_resource_t *resource,
                                         coap_session_t *session,
-                                        const coap_binary_t *token);
+                                        const coap_bin_const_t *token);
 
 /**
  * Flags that data is ready to be sent to observers.
@@ -131,7 +131,7 @@ coap_subscription_t *coap_find_observer(coap_resource_t *resource,
  */
 void coap_touch_observer(coap_context_t *context,
                          coap_session_t *session,
-                         const coap_binary_t *token);
+                         const coap_bin_const_t *token);
 
 /**
  * Removes any subscription for @p observer from @p resource and releases the
@@ -146,7 +146,7 @@ void coap_touch_observer(coap_context_t *context,
  */
 int coap_delete_observer(coap_resource_t *resource,
                          coap_session_t *session,
-                         const coap_binary_t *token);
+                         const coap_bin_const_t *token);
 
 /**
  * Removes any subscription for @p session and releases the allocated storage.

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -234,6 +234,16 @@ coap_context_set_pki_root_cas(coap_context_t *context,
 void coap_context_set_keepalive(coap_context_t *context, unsigned int seconds);
 
 /**
+ * Set the maximum token size (RFC8974).
+ *
+ * @param context        The coap_context_t object.
+ * @param max_token_size The maximum token size.  A value between 8 and 65804
+ *                       inclusive.
+ */
+void coap_context_set_max_token_size(coap_context_t *context,
+                                     size_t max_token_size);
+
+/**
  * Get the libcoap internal file descriptor for using in an application's
  * select() or returned as an event in an application's epoll_wait() call.
  *

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -52,6 +52,10 @@
 /** well-known resources URI */
 #define COAP_DEFAULT_URI_WELLKNOWN ".well-known/core"
 
+/* Extended Token constants */
+#define COAP_TOKEN_DEFAULT_MAX 8
+#define COAP_TOKEN_EXT_MAX 65804 /* 13 + 256 + 65535 */
+
 /* CoAP message types */
 
 /**
@@ -182,11 +186,15 @@ typedef enum coap_pdu_signaling_proto_t {
 /* Applies to COAP_SIGNALING_CSM */
 #define COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE 2
 #define COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER 4
+#define COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH 6
+
 /* Applies to COAP_SIGNALING_PING / COAP_SIGNALING_PONG */
 #define COAP_SIGNALING_OPTION_CUSTODY 2
+
 /* Applies to COAP_SIGNALING_RELEASE */
 #define COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS 2
 #define COAP_SIGNALING_OPTION_HOLD_OFF 4
+
 /* Applies to COAP_SIGNALING_ABORT */
 #define COAP_SIGNALING_OPTION_BAD_CSM_OPTION 2
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -50,6 +50,7 @@ global:
   coap_context_set_keepalive;
   coap_context_set_max_handshake_sessions;
   coap_context_set_max_idle_sessions;
+  coap_context_set_max_token_size;
   coap_context_set_pki;
   coap_context_set_pki_root_cas;
   coap_context_set_psk;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -48,6 +48,7 @@ coap_context_set_csm_timeout
 coap_context_set_keepalive
 coap_context_set_max_handshake_sessions
 coap_context_set_max_idle_sessions
+coap_context_set_max_token_size
 coap_context_set_pki
 coap_context_set_pki_root_cas
 coap_context_set_psk

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -100,6 +100,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
+	@echo ".so man3/coap_context.3" > coap_context_set_max_token_size.3
 	@echo ".so man3/coap_logging.3" > coap_show_pdu.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -161,7 +161,7 @@ OPTIONS - General
    Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
 
 *-T* token::
-   Define the initial starting 'token' for the request.
+   Define the initial starting 'token' for the request (up to 24 characters).
 
 *-U* ::
    Never include Uri-Host or Uri-Port options.

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -20,6 +20,7 @@ coap-rd-notls
 SYNOPSIS
 --------
 *coap-rd* [*-g* group] [*-G* group_if] [*-p* port] [*-v* num] [*-A* address]
+          [*-T* max_token_size]
           [[*-h* hint] [*-k* key]]
           [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* trusted_casfile]]
 
@@ -55,6 +56,9 @@ OPTIONS
 
 *-A* address::
    The local address of the interface which the server has to listen on.
+
+*-T* max_token_size::
+   Set the maximum token length (8-65804).
 
 OPTIONS - PSK
 -------------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -21,7 +21,8 @@ SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-e*] [*-g* group] [*-G* group_if] [*-l* loss]
               [*-p* port] [-r] [*-v* num] [*-A* address] [*-L* value] [*-N*]
-              [*-P* scheme://addr[:port],[name1[,name2..]]] [*-X* size]
+              [*-P* scheme://addr[:port],[name1[,name2..]]]
+              [*-T* max_token_size] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
@@ -104,6 +105,9 @@ OPTIONS - General
    scheme://address[:port] is not defined before the leading , (comma) of the
    first name, then the ongoing connection will be a direct connection.
    Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
+
+*-T* max_token_size::
+   Set the maximum token length (8-65804).
 
 *-X* size::
    Maximum message size to use for TCP based connections (default is 8388864).

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -72,6 +72,8 @@ See
 
 "RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option"
 
+"RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)"
+
 "RFC9175: CoAP: Echo, Request-Tag, and Token Processing"
 
 for further information.

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -20,7 +20,8 @@ coap_context_get_max_handshake_sessions,
 coap_context_set_session_timeout,
 coap_context_get_session_timeout,
 coap_context_set_csm_timeout,
-coap_context_get_csm_timeout
+coap_context_get_csm_timeout,
+coap_context_set_max_token_size
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -53,6 +54,9 @@ const coap_context_t *_context_);*
 unsigned int _csm_timeout_);*
 
 *unsigned int coap_context_get_csm_timeout(const coap_context_t *_context_);*
+
+*void coap_context_set_max_token_size(coap_context_t *_context_,
+size_t _max_token_size_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -112,6 +116,11 @@ _context_.  0 (the default) means wait forever.
 The *coap_context_get_csm_timeout*() function returns the seconds to wait for
 a (TCP) CSM negotiation response from the peer for _context_,
 
+The *coap_context_set_max_token_size*() function sets the _max_token_size_
+for _context_.  _max_token_size_ must be greater than 8 to indicate
+support for RFC8974 up to _max_token_size_ bytes, else 8 to disable RFC8974
+(if previously set).
+
 RETURN VALUES
 -------------
 *coap_new_context*() function returns a newly created context or
@@ -135,8 +144,13 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"RFC7252: The Constrained Application Protocol (CoAP)"
+
+"RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -247,6 +247,9 @@ PDU TOKEN
 The *coap_session_init_token*() function is used to initialize the starting
 _token_ of _length_ for the _session_.
 
+*NOTE:* this only takes the first 8 bytes of the token if extended tokens
+are being used (RFC 8974).
+
 *Function: coap_session_new_token()*
 
 The *coap_session_new_token*() function is used to obtain the next available
@@ -255,13 +258,18 @@ for doing an observe cancellation that was used for doing the observe
 registration.  Otherwise tokens should be unique for each request/response so
 that they can be correctly matched.
 
+*NOTE:* Only a token of up to 8 bytes is returned.
+
 *Function: coap_add_token()*
 
 The *coap_add_token*() function adds in the specified token's _data_ of length
-_length_ to the PDU _pdu_.  The maximum length of the token is 8 bytes.
+_length_ to the PDU _pdu_.  The maximum (but impractical due to PDU sizes)
+length of the token is 65804 bytes.  If anything more than 8, the remote peer
+needs to support extended tokens for this to work.
 Adding the token must be done before any options or data are added.
 This function must only be called once per _pdu_, and must not be called
-in the appropriate request handler.
+in the appropriate request handler as the token has already been added into
+the skeletal response PDU.
 
 If a token is not added, then the token in the PDU is zero length, but still a
 valid token which is used for matching.  The exception is an empty ACK packet.
@@ -702,6 +710,8 @@ See
 "RFC7252: The Constrained Application Protocol (CoAP)"
 
 "RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)"
+
+"RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)"
 
 "RFC9175: CoAP: Echo, Request-Tag, and Token Processing"
 

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -47,8 +47,8 @@ coap_register_async(coap_session_t *session,
 
   SEARCH_PAIR(session->context->async_state, s,
               session, session,
-              pdu->token_length, request->token_length,
-              pdu->token, request->token);
+              pdu->actual_token.length, request->actual_token.length,
+              pdu->actual_token.s, request->actual_token.s);
 
   if (s != NULL) {
     size_t i;
@@ -56,7 +56,8 @@ coap_register_async(coap_session_t *session,
     size_t outbuflen;
 
     outbuf[0] = '\000';
-    for (i = 0; i < request->token_length; i++) {
+    for (i = 0; i < request->actual_token.length; i++) {
+      /* Output maybe truncated */
       outbuflen = strlen(outbuf);
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
                 "%02x", request->token[i]);
@@ -73,11 +74,12 @@ coap_register_async(coap_session_t *session,
     return NULL;
   }
 
+  LL_PREPEND(session->context->async_state, s);
   memset(s, 0, sizeof(coap_async_t));
 
   /* Note that this generates a new MID */
-  s->pdu = coap_pdu_duplicate(request, session, request->token_length,
-                              request->token, NULL);
+  s->pdu = coap_pdu_duplicate(request, session, request->actual_token.length,
+                              request->actual_token.s, NULL);
   if (s->pdu == NULL) {
     coap_free_async(session, s);
     coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
@@ -91,8 +93,6 @@ coap_register_async(coap_session_t *session,
   s->session = coap_session_reference( session );
 
   coap_async_set_delay(s, delay);
-
-  LL_PREPEND(session->context->async_state, s);
 
   return s;
 }
@@ -138,10 +138,11 @@ coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
 coap_async_t *
 coap_find_async(coap_session_t *session, coap_bin_const_t token) {
   coap_async_t *tmp;
+
   SEARCH_PAIR(session->context->async_state, tmp,
               session, session,
-              pdu->token_length, token.length,
-              pdu->token, token.s);
+              pdu->actual_token.length, token.length,
+              pdu->actual_token.s, token.s);
   return tmp;
 }
 

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -371,7 +371,8 @@ msg_option_string(uint8_t code, uint16_t option_type) {
 
   static struct option_desc_t options_csm[] = {
     { COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE, "Max-Message-Size" },
-    { COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" }
+    { COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" },
+    { COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH, "Extended-Token-Length" }
   };
 
   static struct option_desc_t options_pingpong[] = {
@@ -532,7 +533,8 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   char outbuf[COAP_DEBUG_BUF_SIZE];
 #endif /* ! COAP_CONSTRAINED_STACK */
   size_t buf_len = 0; /* takes the number of bytes written to buf */
-  int encode = 0, have_options = 0, i;
+  int encode = 0, have_options = 0;
+  uint32_t i;
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
   int content_format = -1;
@@ -554,10 +556,10 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
           COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
           msg_code_string(pdu->code), pdu->mid);
 
-  for (i = 0; i < pdu->token_length; i++) {
+  for (i = 0; i < pdu->actual_token.length; i++) {
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
-              "%02x", pdu->token[i]);
+              "%02x", pdu->actual_token.s[i]);
   }
   outbuflen = strlen(outbuf);
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "}");
@@ -577,6 +579,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     }
 
     if (pdu->code == COAP_SIGNALING_CODE_CSM) switch(opt_iter.number) {
+    case COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH:
     case COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE:
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                          coap_decode_var_bytes(coap_opt_value(option),

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -217,6 +217,9 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
   session->last_ping_mid = COAP_INVALID_MID;
   session->last_ack_mid = COAP_INVALID_MID;
   session->last_con_mid = COAP_INVALID_MID;
+  session->max_token_size = context->max_token_size; /* RFC8974 */
+  if (session->type != COAP_SESSION_TYPE_CLIENT)
+    session->max_token_checked = COAP_EXT_T_CHECKED;
 
   /* Randomly initialize */
   coap_prng((unsigned char *)&session->tx_mid, sizeof(session->tx_mid));
@@ -493,6 +496,12 @@ void coap_session_send_csm(coap_session_t *session) {
     || coap_add_option_internal(pdu, COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER,
          coap_encode_var_safe(buf, sizeof(buf),
                                 0), buf) == 0
+    || (session->max_token_size > COAP_TOKEN_DEFAULT_MAX &&
+        coap_add_option_internal(pdu,
+                                 COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH,
+                                 coap_encode_var_safe(buf, sizeof(buf),
+                                   session->max_token_size),
+                                 buf) == 0)
     || coap_pdu_encode_header(pdu, session->proto) == 0
   ) {
     coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
@@ -535,10 +544,11 @@ void coap_session_connected(coap_session_t *session) {
   if (session->state != COAP_SESSION_STATE_ESTABLISHED) {
     coap_log(LOG_DEBUG, "***%s: session connected\n",
              coap_session_str(session));
-    if (session->state == COAP_SESSION_STATE_CSM)
+    if (session->state == COAP_SESSION_STATE_CSM) {
       coap_handle_event(session->context, COAP_EVENT_SESSION_CONNECTED, session);
-    if (session->doing_first)
-      session->doing_first = 0;
+      if (session->doing_first)
+        session->doing_first = 0;
+    }
   }
 
   session->state = COAP_SESSION_STATE_ESTABLISHED;

--- a/src/encode.c
+++ b/src/encode.c
@@ -65,7 +65,7 @@ uint64_t
 coap_decode_var_bytes8(const uint8_t *buf, size_t len) {
   unsigned int i;
   uint64_t n = 0;
-  for (i = 0; i < len; ++i)
+  for (i = 0; i < len && i < sizeof(uint64_t); ++i)
     n = (n << 8) + buf[i];
 
   return n;

--- a/src/resource.c
+++ b/src/resource.c
@@ -718,16 +718,15 @@ coap_register_request_handler(coap_resource_t *resource,
 
 coap_subscription_t *
 coap_find_observer(coap_resource_t *resource, coap_session_t *session,
-                     const coap_binary_t *token) {
+                     const coap_bin_const_t *token) {
   coap_subscription_t *s;
 
   assert(resource);
   assert(session);
 
   LL_FOREACH(resource->subscribers, s) {
-    if (s->session == session
-        && (!token || (token->length == s->pdu->token_length
-                       && memcmp(token->s, s->pdu->token, token->length) == 0)))
+    if (s->session == session &&
+        (!token || coap_binary_equal(token, &s->pdu->actual_token)))
       return s;
   }
 
@@ -754,7 +753,7 @@ coap_find_observer_cache_key(coap_resource_t *resource, coap_session_t *session,
 coap_subscription_t *
 coap_add_observer(coap_resource_t *resource,
                   coap_session_t *session,
-                  const coap_binary_t *token,
+                  const coap_bin_const_t *token,
                   const coap_pdu_t *request) {
   coap_subscription_t *s;
   coap_cache_key_t *cache_key = NULL;
@@ -781,8 +780,7 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
       s = coap_find_observer_cache_key(resource, session, cache_key);
       if (s) {
         /* Delete old entry with old token */
-        coap_binary_t tmp_token = { s->pdu->token_length, s->pdu->token };
-        coap_delete_observer(resource, session, &tmp_token);
+        coap_delete_observer(resource, session, &s->pdu->actual_token);
         s = NULL;
       }
     }
@@ -802,8 +800,8 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
   }
 
   coap_subscription_init(s);
-  s->pdu = coap_pdu_duplicate(request, session, request->token_length,
-                              request->token, NULL);
+  s->pdu = coap_pdu_duplicate(request, session, token->length,
+                              token->s, NULL);
   if (s->pdu == NULL) {
     coap_delete_cache_key(cache_key);
     COAP_FREE_TYPE(subscription, s);
@@ -839,7 +837,7 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
 
 void
 coap_touch_observer(coap_context_t *context, coap_session_t *session,
-                    const coap_binary_t *token) {
+                    const coap_bin_const_t *token) {
   coap_subscription_t *s;
 
   RESOURCES_ITER(context->resources, r) {
@@ -852,16 +850,21 @@ coap_touch_observer(coap_context_t *context, coap_session_t *session,
 
 int
 coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
-                     const coap_binary_t *token) {
+                     const coap_bin_const_t *token) {
   coap_subscription_t *s;
 
   s = coap_find_observer(resource, session, token);
 
-  if ( s && coap_get_log_level() >= LOG_DEBUG ) {
+  if (s && coap_get_log_level() >= LOG_DEBUG) {
     char outbuf[2 * 8 + 1] = "";
     unsigned int i;
-    for ( i = 0; i < s->pdu->token_length; i++ )
-      snprintf( &outbuf[2 * i], 3, "%02x", s->pdu->token[i] );
+
+    for ( i = 0; i < s->pdu->actual_token.length; i++ ) {
+      size_t size = strlen(outbuf);
+
+      snprintf(&outbuf[size], sizeof(outbuf)-size, "%02x",
+               s->pdu->actual_token.s[i]);
+    }
     coap_log(LOG_DEBUG,
              "removed subscription %p with token '%s' key 0x%02x%02x%02x%02x\n",
              (void*)s, outbuf, s->cache_key->key[0], s->cache_key->key[1],
@@ -900,7 +903,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                       coap_deleting_resource_t deleting) {
   coap_method_handler_t h;
   coap_subscription_t *obs, *otmp;
-  coap_binary_t token;
+  coap_bin_const_t token;
   coap_pdu_t *response;
   uint8_t buf[4];
   coap_string_t *query;
@@ -953,7 +956,8 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         continue;
       }
 
-      if (!coap_add_token(response, obs->pdu->token_length, obs->pdu->token)) {
+      if (!coap_add_token(response, obs->pdu->actual_token.length,
+                          obs->pdu->actual_token.s)) {
         obs->dirty = 1;
         r->partiallydirty = 1;
         context->observe_pending = 1;
@@ -963,9 +967,6 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         coap_delete_pdu(response);
         continue;
       }
-
-      token.length = obs->pdu->token_length;
-      token.s = obs->pdu->token;
 
       obs->pdu->mid = response->mid = coap_new_message_id(obs->session);
       if ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0 &&
@@ -1136,20 +1137,18 @@ static void
 coap_remove_failed_observers(coap_context_t *context,
                              coap_resource_t *resource,
                              coap_session_t *session,
-                             const coap_binary_t *token) {
+                             const coap_bin_const_t *token) {
   coap_subscription_t *obs, *otmp;
 
   LL_FOREACH_SAFE(resource->subscribers, obs, otmp) {
-    if ( obs->session == session &&
-        token->length == obs->pdu->token_length &&
-        memcmp(token->s, obs->pdu->token, token->length) == 0) {
-
+    if (obs->session == session &&
+        coap_binary_equal(token, &obs->pdu->actual_token)) {
       /* count failed notifies and remove when
        * COAP_OBS_MAX_FAIL is reached */
       obs->fail_cnt++;
       if (obs->fail_cnt >= COAP_OBS_MAX_FAIL) {
         coap_cancel_all_messages(context, obs->session,
-                                 obs->pdu->token, obs->pdu->token_length);
+                                 &obs->pdu->actual_token);
         coap_delete_observer(resource, session, token);
       }
       break;                        /* break loop if observer was found */
@@ -1160,7 +1159,7 @@ coap_remove_failed_observers(coap_context_t *context,
 void
 coap_handle_failed_notify(coap_context_t *context,
                           coap_session_t *session,
-                          const coap_binary_t *token) {
+                          const coap_bin_const_t *token) {
 
   RESOURCES_ITER(context->resources, r) {
     coap_remove_failed_observers(context, r, session, token);


### PR DESCRIPTION
Add in new function coap_context_set_max_token_size() to define the maximum supported token size.

Track changes to PDU to support extended tokens.

Update documentation.